### PR TITLE
Update README for new math notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository collects short notebooks and examples created while reinforcing 
 Introductory mathematics used in machine learning.
 
 - **01_vector_operations.ipynb** – Walkthrough of fundamental vector math with NumPy.  Covers vector definitions, addition, subtraction and scalar multiplication, along with small practical examples.
-- **vector_operations.ipynb** – Extended notebook on vector operations.  Includes additional feature engineering examples such as customer behavior analysis.
+- **02_modulus_and:inner_product.ipynb** – Explores vector modulus (magnitude) and the inner (dot) product using NumPy and Matplotlib visualizations.
 
 ### `supervised_learning`
 Experiments with classical regression algorithms using scikit‑learn.


### PR DESCRIPTION
## Summary
- document new modulus and inner product notebook in `math_for_ml`
- remove reference to obsolete vector_operations.ipynb

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880d07bb004832aabaeba15e2abd801