### PR TITLE
docs: list new datascience folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,10 @@ Experiments with classical regression algorithms using scikit‑learn.
 ### `datascience`
 General data-science workflows organised into subfolders:
 - `01_Scraping/`
-  - `unstructured_notebooks/`
 - `02_SQL/`
-  - `IBM CLOUD/`
-  - `SQL in Python/`
-  - `Script/`
-  - `pdfs/`
+- `03_Data_analysis/`
+- `04_Model_developement/`
+- `05_advanced_plotting/`
 
 ### `Eeg_analysis` and `Fmri_analysis`
 Placeholders for future notebooks exploring EEG and fMRI data.


### PR DESCRIPTION
## Summary
- list new datascience subfolders without per-notebook details
- clarify math_for_ml transcripts note

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68920c94c8e8832aa8f909badb5f8e93